### PR TITLE
Improve automatic file monitoring reliability

### DIFF
--- a/FileOrganizer/FileOrganizer/Services/FileOrganizer.swift
+++ b/FileOrganizer/FileOrganizer/Services/FileOrganizer.swift
@@ -28,7 +28,7 @@ class FileOrganizer: ObservableObject {
     
     private var downloadsURL: URL {
         // Prefer absolute user Downloads path if accessible; fallback to sandbox container path
-        let absolutePath = "~/Downloads"
+        let absolutePath = NSString(string: "~/Downloads").expandingTildeInPath
         let absoluteURL = URL(fileURLWithPath: absolutePath)
         if FileManager.default.fileExists(atPath: absoluteURL.path) {
             return absoluteURL
@@ -281,7 +281,7 @@ class FileOrganizer: ObservableObject {
         }
     }
     
-    private func moveFile(from sourceURL: URL, fileType: FileType) {
+    private func moveFile(from sourceURL: URL, fileType: FileType, retryCount: Int = 3) {
         // Check if confirmation is required
         if preferences.confirmBeforeMoving {
             print("❓ Asking user for confirmation before moving: \(sourceURL.lastPathComponent)")
@@ -294,6 +294,15 @@ class FileOrganizer: ObservableObject {
         // Proceed with automatic move
         print("🚀 Automatically organizing: \(sourceURL.lastPathComponent) → \(fileType.rawValue)")
         performFileMove(from: sourceURL, fileType: fileType)
+
+        // Verify move succeeded, retry if file still exists
+        if FileManager.default.fileExists(atPath: sourceURL.path) && retryCount > 0 {
+            let delay = DispatchTime.now() + .seconds(1)
+            print("⏳ Retrying move in 1s (\(retryCount) retries left): \(sourceURL.lastPathComponent)")
+            processingQueue.asyncAfter(deadline: delay) { [weak self] in
+                self?.moveFile(from: sourceURL, fileType: fileType, retryCount: retryCount - 1)
+            }
+        }
     }
     
     private func performFileMove(from sourceURL: URL, fileType: FileType) {


### PR DESCRIPTION
## Summary
- retry file moves when source file still exists to ensure freshly downloaded files are eventually organized
- correctly expand `~/Downloads` before monitoring to watch the actual user directory

## Testing
- `swift FileOrganizer/test_move.swift`
- `swift FileOrganizer/test_organizer.swift`


------
https://chatgpt.com/codex/tasks/task_e_68a8ed4629b4832199cada7c708d9108